### PR TITLE
Import the 'Mother' framework via a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Mother"]
+	path = Mother
+	url = https://github.com/TruckersInSpace/Mother.git

--- a/ash/build.gradle
+++ b/ash/build.gradle
@@ -11,4 +11,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+	compile project(':Mother:mother')
 }

--- a/ash/src/main/AndroidManifest.xml
+++ b/ash/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="uk.ac.uea.nostromo.ash" android:versionCode="@string/version_code" android:versionName="@string/version_name">
+	<uses-sdk android:minSdkVersion="19" />
     <application />
 </manifest>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':ash'
+include ':ash', ':Mother:mother'


### PR DESCRIPTION
Introduce the 'Mother' framework via a submodule, and modify build
scripts to include the library.

The app makes use of the framework to perform most of the heavy lifting,
and makes only small changes.

This commit also bumps the minimum required Android SDK version to '19'.